### PR TITLE
[fix] Refactor dependency management: extend pyproject.toml, minimize requirements.txt, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,24 @@ PyDrugLogics is available in the CoLoMoTo Docker and Notebook starting from vers
 
 See more about the CoLoMoTo Docker and Notebook in the [documentation](https://colomoto.github.io/colomoto-docker/README.html).<br/>
 
+## Testing
+1. To run all tests and check code coverage, you need to install test dependencies:
+```bash
+    pip install -r requirements.txt
+    pip install -e .[test]
+```
+
+2. Then, from the repository root, run:
+
+```bash
+    pytest tests
+```
+
+You should see a coverage report at the end.
 
 ## Documentation
 
-For full **PyFrugLogics** documentation, visit the [GitHub Documentation](https://druglogics.github.io/pydruglogics/).
+For full **PyDrugLogics** documentation, visit the [GitHub Documentation](https://druglogics.github.io/pydruglogics/).
 
 ## Quick Start Guide
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,38 @@
 [build-system]
 requires = ["setuptools>=42", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "pydruglogics"
+version = "0.1.8"
+description = "Constructing, optimizing Boolean Models and performing in-silico perturbations."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Laura Szekeres"}
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    "Operating System :: POSIX :: Linux",
+    "Intended Audience :: Science/Research",
+    "Topic :: Scientific/Engineering :: Bio-Informatics",
+]
+
+dependencies = [
+    "joblib~=1.4.2",
+    "matplotlib~=3.9.2",
+    "mpbn~=3.8",
+    "numpy~=2.1.3",
+    "pandas~=2.2.3",
+    "pygad~=3.3.1",
+    "scikit-learn~=1.5.2",
+    "scipy~=1.14.1"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-cov"
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-joblib~=1.4.2
-matplotlib~=3.9.2
-mpbn~=3.8
-numpy~=2.1.3
-pandas~=2.2.3
-pygad~=3.3.1
-scikit_learn~=1.5.2
-scipy~=1.14.1
 pyboolnet @ git+https://github.com/hklarner/pyboolnet@3.0.16#egg=pyboolnet


### PR DESCRIPTION
- Added all core and development (test) dependencies to `pyproject.toml`
- Reduced `requirements.txt` to only what is not supported in `pyproject.toml.` . Now it contains only `pyboolnet`, which is not avaiable on PyPi
- Updated the README to reflect new installation and development instructions

Refs #3, #5.