### PR TITLE
[fix] Extend pyproject.toml with dependency, update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,12 @@ The process involves two steps to install the PyDrugLogics core package and its 
 ```bash
 pip install pydruglogics
 ```
-#### 2. Install External Dependency
 
-```bash
-pip install -r https://raw.githubusercontent.com/druglogics/pydruglogics/main/requirements.txt
-```
 This will install the PyDrugLogics package and handle all dependencies automatically.
 
 
 ### Install PyDrugLogics via conda
-*Note*: CoLoMoTo conda integration is ongoing.
+
 ```bash
 conda install szlaura::pydruglogics
 ```
@@ -53,7 +49,6 @@ For the latest development version, you can clone the repository and install dir
 git clone https://github.com/druglogics/pydruglogics.git
 cd pydruglogics
 pip install .
-pip install -r requirements.txt
 ```
 
 ## CoLoMoTo Notebook envionment
@@ -81,7 +76,6 @@ See more about the CoLoMoTo Docker and Notebook in the [documentation](https://c
 ## Testing
 1. To run all tests and check code coverage, you need to install test dependencies:
 ```bash
-    pip install -r requirements.txt
     pip install -e .[test]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
     "pandas~=2.2.3",
     "pygad~=3.3.1",
     "scikit-learn~=1.5.2",
-    "scipy~=1.14.1"
+    "scipy~=1.14.1",
+    "pyboolnet@git+https://github.com/hklarner/pyboolnet@3.0.16#egg=pyboolnet"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-pyboolnet @ git+https://github.com/hklarner/pyboolnet@3.0.16#egg=pyboolnet


### PR DESCRIPTION
Moved pyboolnet dependency to pyproject.toml and updated the new install instructions in the README.