### PR TITLE
[fix] Restore requirements.txt file and add to the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # PyDrugLogics
 
 ![PyDrugLogics Logo](https://raw.githubusercontent.com/druglogics/pydruglogics/main/logo.png)
@@ -31,7 +30,11 @@ The process involves two steps to install the PyDrugLogics core package and its 
 ```bash
 pip install pydruglogics
 ```
+#### 2. Install External Dependency
 
+```bash
+pip install -r https://raw.githubusercontent.com/druglogics/pydruglogics/main/requirements.txt
+```
 This will install the PyDrugLogics package and handle all dependencies automatically.
 
 
@@ -49,9 +52,10 @@ For the latest development version, you can clone the repository and install dir
 git clone https://github.com/druglogics/pydruglogics.git
 cd pydruglogics
 pip install .
+pip install -r requirements.txt
 ```
 
-## CoLoMoTo Notebook envionment
+## CoLoMoTo Notebook environment
 PyDrugLogics is available in the CoLoMoTo Docker and Notebook starting from version `2025-01-01`.
 
 ### Setup CoLoMoTo Docker and Notebook
@@ -76,6 +80,7 @@ See more about the CoLoMoTo Docker and Notebook in the [documentation](https://c
 ## Testing
 1. To run all tests and check code coverage, you need to install test dependencies:
 ```bash
+    pip install -r requirements.txt
     pip install -e .[test]
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ dependencies = [
     "pandas~=2.2.3",
     "pygad~=3.3.1",
     "scikit-learn~=1.5.2",
-    "scipy~=1.14.1",
-    "pyboolnet@git+https://github.com/hklarner/pyboolnet@3.0.16#egg=pyboolnet"
+    "scipy~=1.14.1"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pyboolnet @ git+https://github.com/hklarner/pyboolnet@3.0.16#egg=pyboolnet
+


### PR DESCRIPTION
Due to the PyPi external package restrictions, the PyBoolNet package is installed from requirements.txt file. Updated the README.md and pyproject.toml.